### PR TITLE
View Cart Summary Frontend | Elliot Park

### DIFF
--- a/client/components/app.jsx
+++ b/client/components/app.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import Header from './header';
 import ProductList from './product-list';
 import ProductDetails from './product-details';
+import CartSummary from './cart-summary';
 
 export default class App extends React.Component {
   constructor(props) {
@@ -60,16 +61,21 @@ export default class App extends React.Component {
   render = () => {
     const mainContainerStyle = {
       width: '100vw',
-      height: '100vh'
+      height: '100vh',
+      overflow: 'auto'
     };
+    let currentView = null;
+    if (this.state.view.name === 'catalog') {
+      currentView = <ProductList setView={this.setView} />;
+    } else if (this.state.view.name === 'details') {
+      currentView = <ProductDetails setView={this.setView} viewParams={this.state.view.params} addToCart={this.addToCart} />;
+    } else if (this.state.view.name === 'cart') {
+      currentView = <CartSummary setView={this.setView} cartItems={this.state.cart} />;
+    }
     return (
       <div className="bg-light" style={mainContainerStyle}>
-        <Header cartItemCount={this.state.cart.length} />
-        {
-          this.state.view.name === 'catalog'
-            ? <ProductList setView={this.setView} />
-            : <ProductDetails setView={this.setView} viewParams={this.state.view.params} addToCart={this.addToCart} />
-        }
+        <Header setView={this.setView} cartItemCount={this.state.cart.length} />
+        {currentView}
       </div>
     );
   }

--- a/client/components/cart-summary-item.jsx
+++ b/client/components/cart-summary-item.jsx
@@ -1,0 +1,24 @@
+import React from 'react';
+
+const CartSummaryItem = props => {
+  const imageStyle = {
+    height: 300,
+    objectFit: 'contain'
+  };
+  return (
+    <div className="card mb-3 p-3">
+      <div className="container-fluid">
+        <div className="row d-flex justify-content-around">
+          <img className="col-4" src={props.item.image} style={imageStyle} alt="product image" />
+          <div className="col-6 d-flex flex-column justify-content-center">
+            <h5 className="card-title mb-3">{props.item.name}</h5>
+            <h6 className="card-subtitle text-muted mb-2">{'$' + (props.item.price / 100).toFixed(2)}</h6>
+            <p className="card-text">{props.item.shortDescription}</p>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default CartSummaryItem;

--- a/client/components/cart-summary.jsx
+++ b/client/components/cart-summary.jsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import CartSummaryItem from './cart-summary-item';
+
+const CartSummary = props => {
+  const backToCatalogButtonStyle = {
+    cursor: 'pointer'
+  };
+
+  const cartItemPrices = props.cartItems.map(cartItem => cartItem.price);
+  const cartSubtotal = '$' + (cartItemPrices.reduce((subtotal, value) => subtotal + value) / 100).toFixed(2);
+
+  const cartElement = props.cartItems.length === 0
+    ? <h1 className="d-flex justify-content-center">Your cart is empty.</h1>
+    : props.cartItems.map(cartItem => <CartSummaryItem item={cartItem} key={cartItem.cartItemId} />);
+
+  return (
+    <div className="container-fluid cart-summary-container">
+      <div className="row d-flex justify-content-center">
+        <div className="col-10">
+          <div
+            className="text-muted"
+            style={backToCatalogButtonStyle}
+            onClick={() => props.setView('catalog', {})}>
+            {'<'} Back to Catalog
+          </div>
+          <div className="container-fluid">
+            <div className="row">
+              <h1 className="col text-left p-0">My Cart</h1>
+              <h1 className="col text-right p-0">Subtotal: {cartSubtotal}</h1>
+            </div>
+          </div>
+          { cartElement }
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default CartSummary;

--- a/client/components/header.jsx
+++ b/client/components/header.jsx
@@ -8,7 +8,14 @@ const Header = props => {
           <h2><span className="fas fa-dollar-sign" /> Wicked Sales</h2>
         </div>
         <div className="col-2">
-          <h4>{props.cartItemCount} Items <span className="fas fa-shopping-cart"></span></h4>
+          <h4>
+            {props.cartItemCount} Items
+            <span
+              className="fas fa-shopping-cart"
+              style={{ cursor: 'pointer' }}
+              onClick={() => props.setView('cart', {})}>
+            </span>
+          </h4>
         </div>
       </div>
     </div>

--- a/client/components/product-details.jsx
+++ b/client/components/product-details.jsx
@@ -35,7 +35,7 @@ export default class ProductDetails extends React.Component {
             <div className="col-10">
               <div className="card p-3">
                 <div
-                  className="text-muted bg-white"
+                  className="text-muted"
                   style={backToCatalogButtonStyle}
                   onClick={() => this.props.setView('catalog', {})}>
                   {'<'} Back to Catalog

--- a/client/components/product-list-item.jsx
+++ b/client/components/product-list-item.jsx
@@ -22,7 +22,7 @@ const ProductListItem = props => {
       />
       <div className="card-body d-flex flex-column justify-content-around">
         <h5 className="card-title">{props.name}</h5>
-        <h6 className="card-subtitle text-muted">{'$' + (props.price / 1000).toFixed(2)}</h6>
+        <h6 className="card-subtitle text-muted">{'$' + (props.price / 100).toFixed(2)}</h6>
         <p className="card-text">{props.shortDescription}</p>
       </div>
     </div>


### PR DESCRIPTION
**Changes:**
- Added if-else statement to conditionally render a `CartSummary` when state.view.name === 'cart' (on top of existing views)
- Created `CartSummaryItem` and `CartSummary` components
- Modified `Header` component to include shopping cart icon and number of cart items
- Removed bg-white class from "Back to Catalog" button in `ProductDetails` component 
- Fixed formatting for item price in `ProductListItem` component (was using 1000 as divider instead of 100).

**Screenshots and Gifs:**
Adding an item to cart and viewing cart summary:
![addingItemToCart](https://user-images.githubusercontent.com/16812885/72398316-6fe01580-36f7-11ea-8b7f-9ac61fb1110c.gif)
